### PR TITLE
add bash script for a geological sort of the entries

### DIFF
--- a/Fortran_timeline.md
+++ b/Fortran_timeline.md
@@ -1,0 +1,575 @@
+# Fortran-related books
+Books with Fortran code, other than Fortran textbooks. This branched from the Related Books section of the [Fortran Wiki](http://fortranwiki.org/fortran/show/Books). If you have a book suggestion or if the code of a book is available but not linked here, please create an issue.
+
+# 2021 
+
+ Robey, Robert and Yuliana Zamora (2021). [Parallel and High Performance Computing](https://www.manning.com/books/parallel-and-high-performance-computing). Manning 
+
+ Ramkarthik, M.S., and Payal D. Solanki (2021). [Numerical Recipes in Quantum Information Theory and Quantum Computing: An Adventure in FORTRAN 90](https://www.routledge.com/Numerical-Recipes-in-Quantum-Information-Theory-and-Quantum-Computing-An/Ramkarthik-Solanki/p/book/9780367759285). 
+
+# 2020 
+
+ Salmi, Tapio, Johan Wärnå , José Rafael Hernández Carucci and César A. de Araújo Filho (2020). [Chemical Reaction Engineering: A Computer-Aided Approach](https://www.degruyter.com/document/doi/10.1515/9783110611601/html). De Gruyter 
+
+ Ramos, Juan Antonio Hernandez, and Lopez, Javier Escoto (2020). [How to learn Applied Mathematics through modern FORTRAN](http://www.amazon.com/dp/B0851LN6HT/fortran-wiki-20/fortran-wiki-20). Independently published [code and text](https://github.com/jahrWork/NumericalHUB) 
+
+ Neculai, Andrei (2020). [Nonlinear Conjugate Gradient Methods for Unconstrained Optimization](https://www.springer.com/gp/book/9783030429492). Springer. Fortran codes at author’s [site](https://camo.ici.ro/neculai/ansoft.htm) 
+
+ Kitagawa, Genshiro (2020). [Introduction to Time Series Modeling with Applications in R](https://www.routledge.com/Introduction-to-Time-Series-Modeling-with-Applications-in-R/Kitagawa/p/book/9780367187330). CRC. Associated R package [TSSS: Time Series Analysis with State Space Model](https://cran.r-project.org/web/packages/TSSS/index.html) has Fortran code. 
+
+ Bagirov, Adil, Napsu Karmitsa, and Sona Taheri (2020). [Partitional Clustering via Nonsmooth Optimization](http://napsu.karmitsa.fi/). Springer 
+
+ Bagirov, Adil, M. Gaudioso, N. Karmitsa, M. M. Mäkelä, and S. Taheri, (Eds.), (2020). [Numerical Nonsmooth Optimization: State of the Art Algorithms](http://napsu.karmitsa.fi/). Springer 
+
+# 2019 
+
+ Yanushevsky, Rafael (2019). [Modern Missile Guidance, 2nd ed.](https://www.routledge.com/Modern-Missile-Guidance/Yanushevsky/p/book/9780815384861). CRC 
+
+ Røed, Lars Petter (2019). [Atmospheres and Oceans on Computers: Fundamental Numerical Methods for Geophysical Fluid Dynamics](https://www.springer.com/us/book/9783319938639). Springer. Has appendix [Introduction to Fortran 2003 via Examples](https://link.springer.com/content/pdf/bbm%3A978-3-319-93864-6%2F1.pdf) 
+
+ Mattson, Timothy G., Yun (Helen) He, and Alice E. Koniges (2019). [The OpenMP Common Core: Making OpenMP Simple Again](https://mitpress.mit.edu/books/openmp-common-core). MIT Press 
+
+ Francq, Christian and Jean‐Michel Zakoian (2019). [GARCH Models: Structure, Statistical Inference and Financial Applications, 2nd. ed.](https://onlinelibrary.wiley.com/doi/book/10.1002/9781119313472). Wiley. Code at Francq’s [site](http://christian.francq140.free.fr/Christian-Francq/GARCH-Models/Identification/portmanteau.html) 
+
+ Bose, Sujit Kumar (2019). [Numerical Methods of Mathematics Implemented in Fortran](https://www.springer.com/gp/book/9789811371134). Springer. reviewed [here](https://www.maa.org/press/maa-reviews/numerical-methods-of-mathematics-implemented-in-fortran) 
+
+# 2018 
+
+ Zubairi, Omair and Fridolin Weber (2018). [Introduction to Computational Physics for Undergraduates](https://iopscience.iop.org/book/978-1-6817-4896-2). Morgan & Claypool 
+
+ Trapp, Michael, and Andreas Öchsner (2018). [Computational Plasticity for Finite Elements: A Fortran-Based Introduction](https://www.springer.com/us/book/9783319772059). Springer 
+
+ Sewell, Granville (2018). [Solving Partial Differential Equation Applications with PDE2D](http://www.pde2d.com/). Wiley 
+
+ Lee, Wen Ho (2018). [Computational Solid Mechanics for Oil Well Perforator Design](https://www.worldscientific.com/worldscibooks/10.1142/10966#t=toc). World Scientific 
+
+ Izaac, Joshua, and Jingbo Wang (2018). [Computational Quantum Mechanics](https://www.springer.com/gp/book/9783319999296). Springer 
+
+ Fehr, Hans and Kindermann, Fabian (2018). [Introduction to Computational Economics Using Fortran](http://fortranwiki.org/fortran/show/Introduction+to+Computational+Economics+Using+Fortran). Oxford University Press. 
+
+ Bestehorn, Michael (2018). [Computational Physics With Worked Out Examples in FORTRAN and MATLAB](https://www.degruyter.com/document/doi/10.1515/9783110515145/html). De Gruyter 
+
+# 2017 
+
+ Singh, Nathi (2017). [Computational Methods for Physics and Mathematics: With Fortran and C Programmes](https://www.amazon.com/Computational-Methods-Physics-N-Kushwaha/dp/1783322128/fortran-wiki-20). Alpha Science 
+
+ Pozrikidis, C. (2017). [Fluid Dynamics: Theory, Computation, and Numerical Simulation, 3rd ed.](http://dehesa.freeshell.org/FD3/). Springer 
+
+ Javanbakht, Zia, and Andreas Öchsner (2017). [Advanced Finite Element Simulation with MSC Marc: Application of User Subroutines](https://www.springer.com/us/book/9783319476674). Springer 
+
+ De Gooijer, Jan G. (2017). [Elements of Nonlinear Time Series Analysis and Forecasting](https://www.springer.com/us/book/9783319432519). Springer 
+
+ Allen, Michael P. and Dominic J. Tildesley (2017). [Computer Simulation of Liquids, 2nd. ed.](https://global.oup.com/academic/product/computer-simulation-of-liquids-9780198803195?cc=us&lang=en&). Oxford University Press. code at [GitHub](https://github.com/Allen-Tildesley/examples) 
+
+# 2016 
+
+ White, Robert E. (2016). [Computational Mathematics Models, Methods, and Analysis with MATLAB® and MPI, 2nd ed.](https://www.routledge.com/Computational-Mathematics-Models-Methods-and-Analysis-with-MATLAB-and/White/p/book/9781482235159). CRC 
+
+ Walker, Darren (2016). [Computational Physics](https://www.amazon.com/Computational-Physics-Essentials-Darren-Walker/dp/1942270739/fortran-wiki-20). Mercury Learning. Code at [GitHub](https://github.com/DJWalker42/ComputationalPhysicsFortran). 
+
+ Norouzi, Hamid Reza, Reza Zarghami, Rahmat Sotudeh-Gharebagh, and Navid Mostoufi (2016). [Coupled CFD-DEM Modeling: Formulation, Implementation and Application to Multiphase Flows](https://www.wiley.com//legacy/wileychi/norouzi/). Wiley 
+
+ Burden, Richard, L., J. Douglas Faires and Annette M. Burden (2016). [Numerical Analysis, 10th ed.](https://www.cengage.com/c/numerical-analysis-10e-burden/9781305253667PF/). Cengage. FORTRAN 77 code [here](https://sites.google.com/site/numericalanalysis1burden/home) 
+
+ Britz, Dieter, and Jörg Strutwolf (2016). [Digital Simulation in Electrochemistry](https://www.springer.com/us/book/9783319302904). Springer. Appendix E describes a number of example programs in Fortran. 
+
+ Anagnostopoulos, Konstantinos (2016). [Computational Physics](http://www.physics.ntua.gr/konstant/ComputationalPhysics/). freely available in Fortran and C++ versions 
+
+# 2015 
+
+ Sewell, Granville (2015) [The Numerical Solution of Ordinary and Partial Differential Equations, 3rd Ed.](http://math.utep.edu/Faculty/sewell/odes_pdes/). World Scientific 
+
+ Huang, Haibo, Michael C. Sukop, and Xi-Yun Lu (2015). [Multiphase Lattice Boltzmann Methods: Theory and Application](https://www.wiley.com/legacy/wileychi/huang/). Wiley 
+
+ Blazek, Jiri (2015). [Computational Fluid Dynamics: Principles and Applications, 3rd ed.](https://booksite.elsevier.com/9780080999951/). Butterworth-Heinemann 
+
+ Algazin, Sergey D., and Igor A. Kijko (2015). [Aeroelastic Vibrations and Stability of Plates and Shells](https://www.degruyter.com/document/doi/10.1515/9783110338379/html). De Gruyter 
+
+# 2014 
+
+ Sewell, Granville (2014). [Computational Methods of Linear Algebra, 3rd ed.](http://math.utep.edu/Faculty/sewell/computational_methods/). World Scientific 
+
+ Birgin, E.G., and J. M. Martínez (2014). [Practical Augmented Lagrangian Methods for Constrained Optimization](https://www.ime.usp.br/~egbirgin/tango/publications.php). SIAM 
+
+ Bathe, Klaus-Jurgen (2014). [Finite Element Procedures, 2nd ed.](https://www.amazon.com/Finite-Element-Procedures-Klaus-J%C3%BCrgen-Bathe/dp/0979004950). Prentice Hall. Text [here](https://web.mit.edu/kjb/www/Books/FEP_2nd_Edition_4th_Printing.pdf) Related code [ADINA](http://www.adina.com/educ.shtml), [OpenSTAP](https://github.com/HaoguangYang/OpenSTAP), and [STAP90](https://github.com/weixiao-huang/STAP90) 
+
+ Bagirov, Adil, Napsu Karmitsa, and Marko M. Mäkelä (2014). [Introduction to Nonsmooth Optimization: Theory, Practice and Software](http://napsu.karmitsa.fi/). Springer 
+
+# 2013 
+
+ Zienkiewicz, O.C., R. L. Taylor, and J.Z. Zhu (2013). [The Finite Element Method: Its Basis and Fundamentals 
+
+ Zienkiewicz, O.C., and R. L. Taylor (2013). [The Finite Element Method for Solid and Structural Mechanics, 7th Ed.](https://www.elsevier.com/books/the-finite-element-method-for-solid-and-structural-mechanics/zienkiewicz/978-1-85617-634-7). Elsevier. [feappv code at GitHub](https://github.com/sanjayg0/feappv) 
+
+ Smylie, D. E. (2013). [Earth Dynamics: Deformations and Oscillations of the Rotating Earth](https://www.yorku.ca/smylie/). Cambridge University Press 
+
+ Smith, I.M., D. V. Griffiths, and L. Margetts (2013). [Programming the Finite Element Method, 5th Edition](https://www.wiley.com/en-us/Programming+the+Finite+Element+Method%2C+5th+Edition-p-9781119973348). Wiley. Code at Griffiths’ [site](http://inside.mines.edu/~vgriffit/) 
+
+ Schattke, Wolfgang, and Ricardo Díez Muiño (2013).[Quantum Monte-Carlo Programming: For Atoms, Molecules, Clusters, and Solids](https://www.wiley.com/en-us/Quantum+Monte+Carlo+Programming%3A+For+Atoms%2C+Molecules%2C+Clusters%2C+and+Solids-p-9783527675326). Wiley. 
+
+ Ruetsch, Gregory and Fatica, Massimiliano (2013). [CUDA Fortran for Scientists and Engineers](http://fortranwiki.org/fortran/show/CUDA+Fortran+for+Scientists+and+Engineers). Morgan Kaufmann. 
+
+ Helffrich, George, James Wookey, and Ian Bastow (2013). [The Seismic Analysis Code: A Primer and User's Guide](https://www.cambridge.org/us/academic/subjects/earth-and-environmental-science/solid-earth-geophysics/seismic-analysis-code-primer-and-users-guide). Cambridge. Code [here](https://github.com/ghfbsd/sacbook) and manual [here](http://www.adc1.iris.edu/files/sac-manual/sac_manual.pdf). 
+
+ Gu, Chong (2013). [Smoothing Spline ANOVA Models, 2nd ed.](https://www.stat.purdue.edu/~chong/book/). Springer 
+
+ Golub, Gene, and Charles Van Loan (2013). [Matrix Computations, 4th ed.](https://www.amazon.com/Computations-Hopkins-Studies-Mathematical-Sciences/dp/1421407949/fortran-wiki-20). Johns Hopkins 
+
+ Fenner, Roger T. (2013). [Finite Element Methods For Engineers, 2nd ed.](https://www.amazon.com/Finite-Element-Methods-Engineers-Fenner/dp/B004VSJ030/fortran-wiki-20). Imperial College Press 
+
+ Engeln-Müllges, Gisela and Uhlig, Frank (2013). [Numerical Algorithms with Fortran](http://fortranwiki.org/fortran/show/Numerical+Algorithms+with+Fortran). Springer. 
+
+ Brázdová, Veronika, and David R. Bowler (2013). [Atomistic Computer Simulations: A Practical Guide](http://davidbowler.github.io/AtomisticSimulations/index.html). Wiley. 
+
+# 2012 
+
+ Markus, Arjen (2012). [Modern Fortran in Practice](http://fortranwiki.org/fortran/show/Modern+Fortran+in+Practice). Cambridge University Press. 
+
+ LeVeque, Randall J. (2012). [Finite Volume Methods for Hyperbolic Problems](http://www.clawpack.org/book.html). Cambridge University Press 
+
+ Cheney, Ward and David Kincaid (2012). [Numerical Mathematics and Computing, 7th ed.](https://web.ma.utexas.edu/CNA/NMC7/). Brooks/Cole: Cengage Learning 
+
+ Antia, H.M. (2012). [Numerical methods for scientists and engineers, 3rd ed.](https://www.tifr.res.in/~antia/nmse3.html) Hindustan Book Agency. 
+
+# 2011 
+
+ Skiena, Steven (2011). [Algorithm Design Manual, 3rd ed.](https://www.algorist.com/). Fortran codes [here](https://algorist.com/languages/Fortran.html) 
+
+ Saad, Yousef (2011). [Numerical Methods for Large Eigenvalue Problems - 2nd Edition](https://www-users.cs.umn.edu/~saad/eig_book_2ndEd.pdf). SIAM 
+
+ Rouson, D., J. Xia, and X. Xu (2011). [Scientific Software Design - The Object-Oriented Way](http://fortranwiki.org/fortran/show/Scientific+Software+Design+-+The+Object-Oriented+Way). Cambridge University Press. 
+
+ Pozrikidis, C. (2011). [Introduction to Theoretical and Computational Fluid Dynamics, 2nd. ed.](http://dehesa.freeshell.org/TCFD2/). Oxford 
+
+ Monahan, John F. (2011). [Numerical Methods of Statistics, 2nd ed.](https://www4.stat.ncsu.edu/~monahan/nmos2/toc.html). Cambridge University Press 
+
+ Gibbs, B. P. (2011). [Advanced Kalman Filtering, Least-Squares, and Modeling, A Practical Handbook](https://onlinelibrary.wiley.com/doi/book/10.1002/9780470890042). Wiley. The software is included in a single zip file (Gibbs_Software_1_2.zip) located at web site ftp://ftp.wiley.com/public/sci_tech_med/least_squares/ 
+
+ Clerman, Norman S. and Spector, Walter (2011). [Modern Fortran - Style and Usage](http://fortranwiki.org/fortran/show/Modern+Fortran+-+Style+and+Usage). Cambridge University Press. [reviewed](https://www.jstatsoft.org/article/view/v047b01) in the Journal of Statistical Software 
+
+# 2010 
+
+ Wellek, Stefan (2010). [Testing Statistical Hypotheses of Equivalence and Noninferiority, 2nd ed.](https://www.routledge.com/Testing-Statistical-Hypotheses-of-Equivalence-and-Noninferiority/Wellek/p/book/9781439808184). CRC 
+
+ Weiland, Claus (2010). [Computational Space Flight Mechanics](https://www.springer.com/us/book/9783642135828). Springer 
+
+ Olver, Frank W. J., Daniel W. Lozier, Ronald F. Boisvert, and Charles W. Clark (2010). [NIST Handbook of Mathematical Functions](https://www.cambridge.org/catalogue/catalogue.asp?isbn=9780521192255). Cambridge University Press. Associated with the [NIST Digital Library of Mathematical Functions](https://dlmf.nist.gov/) 
+
+ Kantz, Holger, and Thomas Schreiber (2010). [Nonlinear Time Series Analysis](https://www.cambridge.org/core/books/nonlinear-time-series-analysis/519783E4E8A2C3DCD4641E42765309C7). Cambridge University Press. Associated software: [TISEAN](https://www.pks.mpg.de/tisean//Tisean_3.0.1/index.html) 
+
+ Kampf, Jochen (2010). [Advanced Ocean Modelling: Using Open-Source Software](https://www.springer.com/gp/book/9783642106095). Springer 
+
+ Hager, Georg and Gerhard Wellein (2010). [Introduction to High Performance Computing for Scientists and Engineers](https://blogs.fau.de/hager/hpc-book). CRC 
+
+ Chung, T. J. (2010). [Computational Fluid Dynamics, 2nd ed.](https://www.cambridge.org/ar/academic/subjects/engineering/thermal-fluids-engineering/computational-fluid-dynamics-2nd-edition?format=HB&isbn=9780521769693). Cambridge University Press 
+
+# 2009 
+
+ Thompson, Ian J., and Filomena M. Nunes (2009). [Nuclear Reactions for Astrophysics: Principles, Calculation and Applications of Low-Energy Reactions](http://www.fresco.org.uk/book/reactions.htm). Cambridge University Press 
+
+ Neder, Reinhard B., and Thomas Proffen (2009). [Diffuse Scattering and Defect Structure Simulations: A Cook Book Using the Program DISCUS](https://oxford.universitypressscholarship.com/view/10.1093/acprof:oso/9780199233694.001.0001/acprof-9780199233694). Oxford University Press. Code at [GitHub](http://tproffen.github.io/DiffuseCode/) 
+
+ Kopriva, David (2009). [Implementing Spectral Methods for Partial Differential Equations: Algorithms for Scientists and Engineers](https://www.springer.com/us/book/9789048122608). Springer. Has Fortran-friendly pseudo-code. The author has contributed routines to the [HORSES2D](https://github.com/horsescfd/HORSES2D) high-order spectral element solver in Fortran. 
+
+ Evensen, Geir (2009). [Data assimilation, The Ensemble Kalman Filter, 2nd ed.](https://enkf.nersc.no/). Springer 
+
+ Curotto, Emanuele (2009). [Stochastic Simulations of Clusters: Quantum Methods in Flat and Curved Spaces](https://www.routledge.com/Stochastic-Simulations-of-Clusters-Quantum-Methods-in-Flat-and-Curved-Spaces/Curotto/p/book/9781420082258). CRC 
+
+# 2008 
+
+ Pozrikidis, C. (2008). [Numerical Computation in Science and Engineering, 2nd. ed.](http://dehesa.freeshell.org/NCSE2/). Oxford University Press 
+
+ Hjorth-Jensen, Morton (2008). [Computational Physics](https://www.uio.no/studier/emner/matnat/fys/FYS3150/h08/undervisningsmateriale/Lecture%20Notes/lecture2008.pdf). 
+
+ Fenton, Gordon A., and D. V. Griffiths (2008). [Risk Assessment in Geotechnical Engineering](http://random.engmath.dal.ca/rfem/). Wiley 
+
+ de Souza Neto, E.A., D. Peri, and D.R.J. Owen (2008). [Computational Methods for Plasticity: Theory and Applications](https://www.wiley.com/legacy/wileychi/desouzaneto/). Wiley. Code at book site and also [GitHub](https://github.com/mestradam/hyplas) 
+
+ Beer, Gernot, Ian Smith, and Christian Duenser (2008). [The Boundary Element Method with Programming For Engineers and Scientist](https://www.springer.com/us/book/9783211715741). Springer 
+
+# 2007 
+
+ Mielke, Jr., Paul W., and Kenneth J. Berry (2007). [Permutation Methods: A Distance Function Approach](https://www.springer.com/gp/book/9781475734492). Springer. code at Mielke’s [site](https://www.stat.colostate.edu/~mielke/permute.html) 
+
+ Keeling, Matt J. and Pej Rohani (2007). [Modeling Infectious Diseases in Humans and Animals](http://www.modelinginfectiousdiseases.org). Princeton University Press 
+
+ Epps, Thomas W. (2007). [Pricing Derivative Securities, 2nd. ed.](https://www.worldscientific.com/worldscibooks/10.1142/6243#t=suppl). World Scientific 
+
+ Chapman, Barbara *et al.* (2007). [Using OpenMP - Portable Shared Memory Parallel Programming](http://fortranwiki.org/fortran/show/Using+OpenMP+-+Portable+Shared+Memory+Parallel+Programming). MIT Press. 
+
+# 2006 
+
+ Pang, Tao (2006). [An Introduction to Computational Physics, 2nd Edition](http://www.physics.unlv.edu/~pang/cp2.html). Cambridge University Press 
+
+ Oliveira, Suely and Stewart, David (2006). [Writing Scientific Software - A Guide to Good Style](http://fortranwiki.org/fortran/show/Writing+Scientific+Software+-+A+Guide+to+Good+Style). Cambridge University Press. 
+
+ Nocedal, Jorge, and Stephen J. Wright (2006). [Numerical Optimization](http://users.iems.northwestern.edu/~nocedal/book/index.html). Springer. Related code at Nocedal’s [site](http://users.iems.northwestern.edu/~nocedal/software.html) 
+
+ Klein, Andi, and Alexander Godunov (2006). [Introductory Computational Physics](https://ww2.odu.edu/~agodunov/comp_physics.html). Cambridge University Press. codes in Fortran and C++ 
+
+ Griffiths, D. Vaughan, and I.M. Smith (2006). [Numerical Methods for Engineers, 2nd ed.](https://www.routledge.com/Numerical-Methods-for-Engineers/Griffiths-Smith/p/book/9780367390662). CRC. Code at Griffiths’ [site](http://inside.mines.edu/~vgriffit/) 
+
+# 2005 
+
+ Scott, L. Ridgway, Terry Clark, and Babak Bagheri (2005). [Scientific Parallel Computing](http://spcbook.cs.uchicago.edu/about.html). Princeton University Press 
+
+ Reddy, J. N. (2005). [An Introduction to the Finite Element Method, 3rd ed.](http://highered.mheducation.com/sites/0072466855/index.html). McGraw-Hill. Code [here](https://mechanics.tamu.edu/fem-codes-from-linear-fem-book-in-fortran/) 
+
+ Greenspan, Donald (2005). [Molecular and Particle Modelling of Laminar and Turbulent Flows](https://www.worldscientific.com/worldscibooks/10.1142/5702#t=suppl). World Scientific 
+
+ Giordano, Nicholas J., and Hisao Nakanishi (2005). [Computational Physics](http://www.physics.purdue.edu/~hisao/book/). Prentice-Hall 
+
+# 2004 
+
+ Tanizaki, Hisashi (2004). [Computational Methods in Statistics and Econometrics](http://www2.econ.osaka-u.ac.jp/~tanizaki/cv/books/cmse/cmse.pdf). CRC Press 
+
+ Berg, Bernd A (2004). [Markov Chain Monte Carlo Simulations and Their Statistical Analysis – With Web-Based Fortran Code](https://www.worldscientific.com/worldscibooks/10.1142/5602). World Scientific 
+
+# 2003 
+
+ Watson, Neville, and Jos Arrillaga (2003). [Power Systems Electromagnetic Transients Simulation](https://digital-library.theiet.org/content/books/po/pbpo039e). Institution of Engineering and Technology 
+
+ Santner, Thomas J., Brian J. Williams, and William I. Notz (2003). [The Design and Analysis of Computer Experiments](https://www.asc.ohio-state.edu/statistics/comp_exp//book.html). Springer 
+
+ Saad, Yousef (2003). [Iterative Methods for Sparse Linear Systems, 2nd Edition](https://www-users.cs.umn.edu/~saad/IterMethBook_2ndEd.pdf). SIAM 
+
+ Liu, G.R., and M. B. Liu (2003). [Smoothed Particle Hydrodynamics: A Meshfree Particle Method](https://www.worldscientific.com/worldscibooks/10.1142/5340). World Scientific. Code at site and at [GitHub](https://github.com/QuantumWarlock/LiuBook_SPH3D) 
+
+ Lee, H.J., and W.E. (2003). [Ordinary and Partial Differential Equation Routines in C, C++, Fortran, Java, Maple, and MATLAB](https://www.routledge.com/Ordinary-and-Partial-Differential-Equation-Routines-in-C-C-Fortran/Lee-Schiesser/p/book/9781584884231). Chapman and Hall/CRC 
+
+ Green, Peter J., Nils Lid Hjort, and Sylvia Richardson (2003). [Highly Structured Stochastic Systems](https://global.oup.com/academic/product/highly-structured-stochastic-systems-9780198510550?cc=us&lang=en&). Oxford University Press. Related code at Green’s [site](https://people.maths.bris.ac.uk/~mapjg/AutoRJ/) 
+
+ Farrashkhalvat, M., and J.P. Miles (2003). [Basic Structured Grid Generation, with an introduction to unstructured grid generation](https://www.sciencedirect.com/book/9780750650588/basic-structured-grid-generation). Butterworth-Heinemann 
+
+ De Graef, Marc (2003). [Introduction to Conventional Transmission Electron Microscopy](http://ctem.web.cmu.edu/frames.html). Cambridge University Press 
+
+ Bhatt, Prab (2003). [Programming the Dynamic Analysis of Structures](https://www.routledge.com/Programming-the-Dynamic-Analysis-of-Structures/Bhatt/p/book/9780367863494). CRC 
+
+# 2002 
+
+ Schittkowski, Klaus (2002). [Numerical Data Fitting in Dynamical Systems - A Practical Introduction with Applications and Software](http://klaus-schittkowski.de/dyn_sys_book.htm). Kluwer 
+
+ Nguyen, Duc Thai (2002). [Parallel-Vector Equation Solvers for Finite Element Engineering Applications](https://www.springer.com/us/book/9780306466403). Springer 
+
+ Miller, Alan (2002). [Subset Selection in Regression, 2nd ed.](https://www.routledge.com/Subset-Selection-in-Regression/Miller/p/book/9780367396220). Chapman and Hall/CRC. code at Miller’s [site](https://jblevins.org/mirror/amiller/) 
+
+ Kincaid, David and Ward Cheney (2002). [Numerical Analysis: Mathematics of Scientific Computing, 3rd ed.](https://bookstore.ams.org/amstext-2). American Mathematical Society. Code [here](https://web.ma.utexas.edu/CNA/NA3/sample.html) 
+
+ Ferziger, Joel H., Peric, Milovan, and Street, Robert L. (2002). [Computational Methods for Fluid Dynamics](http://cfd-peric.de/). Springer 
+
+# 2001 
+
+ Roe, Byron P. (2001). [Probability and Statistics in Experimental Physics](https://www.springer.com/gp/book/9780387951638). Springer 
+
+ Nazareth, J.L. (2001). [DLP and Extensions: An Optimization Model and Decision Support System](https://www.springer.com/us/book/9783540411147). Springer. DLPEDU code [here](http://www.math.wsu.edu/faculty/nazareth/dlpedu-ebook.pdf) 
+
+ Katz, Joseph and Allen Plotkin (2001). [Low-Speed Aerodynamics](https://www.cambridge.org/core/books/lowspeed-aerodynamics/077FAF851C4582F1B7593809752C44AE). Cambridge University Press. Code at [GitHub](https://github.com/cibinjoseph/KatzPlotkin) 
+
+ Goedecker, Stefan, and Adolfy Hoisie (2001). [Performance Optimization of Numerically Intensive Codes](https://epubs.siam.org/doi/book/10.1137/1.9780898718218). SIAM. Codes [here](https://archive.siam.org/books/set12/). 
+
+ Cook, Robert D., David S. Malkus, Michael E. Plesha, and Robert J. Witt (2001). [Concepts and Applications of Finite Element Analysis, 4th ed.](https://www.amazon.com/Concepts-Applications-Finite-Element-Analysis/dp/0471356050). Wiley 
+
+ Boyd, John P. (2001). [Chebyshev and Fourier Spectral Methods](https://store.doverpublications.com/0486411834.html). Dover. Modified code [here](https://gist.github.com/ivan-pi/1b476dabd11b651fc2ea6e4fd0c11289) 
+
+ Beer, Gernot (2001). [Programming the Boundary Element Method: An Introduction for Engineers](https://www.wiley.com/en-us/Programming+the+Boundary+Element+Method%3A+An+Introduction+for+Engineers-p-9780471863335). Wiley 
+
+ Alexandrou, Andreas N. (2001). [Principles of Fluid Mechanics](https://www.pearson.com/us/higher-education/program/Alexandrou-Principles-of-Fluid-Mechanics/PGM211531.html). Prentice-Hall 
+
+# 2000 
+
+ Orlandi, Paolo (2000). [Fluid Flow Phenomena: A Numerical Toolkit](https://www.springer.com/us/book/9781402003899). Kluwer. Code at author's [site](http://dma.ing.uniroma1.it/users/orlandi/resume.html) 
+
+ Fletcher, R. (2000). [Practical Methods of Optimization, 2nd Edition](https://www.wiley.com/en-us/Practical+Methods+of+Optimization%2C+2nd+Edition-p-9780471494638). Wiley 
+
+ Chandra, Rohit, Ramesh Menon, Leo Dagum, David Kohr, Dror Maydan, and Jeff McDonald (2000). [Parallel Programming in OpenMP](https://www.elsevier.com/books/parallel-programming-in-openmp/chandra/978-1-55860-671-5). Morgan Kaufmann 
+
+# 1999 
+
+ Pozrikidis, C. (1999). [Little Book of Streamlines](http://dehesa.freeshell.org/LBS/). Academic Press 
+
+ Law, Averill M., and W. David Kelton (1999). [Simulation Modeling and Analysis, 3rd. ed](https://www.amazon.com/Simulation-Modeling-Industrial-Engineering-Management/dp/0070592926). McGraw-Hill 
+
+ Kernighan, Brian W. and Pike, Rob (1999). [The Practice of Programming](http://fortranwiki.org/fortran/show/The+Practice+of+Programming). Addison-Wesley. 
+
+ Gropp W., Lusk, E. and Skjellum, A. (1999). [Using MPI - Portable Parallel Programming with the Message Passing Interface](http://fortranwiki.org/fortran/show/Using+MPI+-+Portable+Parallel+Programming+with+the+Message+Passing+Interface). The MIT Press. 
+
+ Brandt, Siegmund (1999). [Data Analysis: Statistical and Computational Methods for Scientists and Engineers](https://www.springer.com/gp/book/9780387984988). Springer 
+
+# 1998 
+
+ Vowels, Robin A. (1998). [Algorithms and Data Structures in F and Fortran](http://pages.swcp.com/~walt/fortran_store/Html/Info/books/adsff.html). Unicomp 
+
+ Snir, Marc and Gropp, William (1998). [MPI - The Complete Reference](http://fortranwiki.org/fortran/show/MPI+-+The+Complete+Reference). The MIT Press. 
+
+ Pao, Yen-Ching (1998). [Engineering Analysis: Interactive Methods and Programs with FORTRAN, QuickBASIC, MATLAB, and Mathematica](https://www.routledge.com/Engineering-Analysis-Interactive-Methods-and-Programs-with-FORTRAN-QuickBASIC/Pao/p/book/9780849320163). CRC Press 
+
+ Lucquin, Brigitte, and Olivier Pironneau (1998). [Introduction to Scientific Computing](https://www.wiley.com/en-us/Introduction+to+Scientific+Computing-p-9780471972662). Wiley. Fortran and C code at Pironneau’s [site](https://www.ljll.math.upmc.fr/pironneau/) 
+
+ Kahaner, David, Cleve Moler, and Stephen Nash (1998). [Numerical Methods and Software](https://www.amazon.com/Numerical-Methods-Software-Disk-Included/dp/0136272584/fortran-wiki-20). Prentice Hall. Fortran 90 code [here](https://people.sc.fsu.edu/~jburkardt/f_src/nms/nms.html) 
+
+ Fornberg, Bengt (1998). [A Practical Guide to Pseudospectral Methods](https://www.cambridge.org/core/books/practical-guide-to-pseudospectral-methods/A480974AF6FAF85BF2DBC1D17F195A82). Cambridge University Press. 
+
+ Fletcher, C. A. J. (1998). [Computational Techniques for Fluid Dynamics 1: Fundamental and General Techniques](https://www.springer.com/us/book/9783540530589). Springer 
+
+ Axelrod, Robert (1998). [The Complexity of Cooperation: Agent-Based Models of Competition and Collaboration](http://www-personal.umich.edu/~axe/research/Software/ComplexCoop.html). Princeton University Press. Code [here](http://www-personal.umich.edu/~axe/research/Software/CC/CC2.html) 
+
+# 1997 
+
+ Thompson, William J. (1997). [Atlas for Computing Mathematical Functions: An Illustrated Guide for Practitioners with Programs in FORTRAN and Mathematica](https://www.wolfram.com/books/profile.cgi?id=3844). Wiley 
+
+ Smetana, Frederick O. (1997). [Introductory Aerodynamics and Hydrodynamics of Wings and Bodies: A Software-Based Approach](https://www.amazon.com/gp/product/1563472422/fortran-wiki-20). American Institute of Aeronautics & Astronautics 
+
+ Schiesser, W. E., and C. A. Silebi (1997). [Computational Transport Phenomena: Numerical Methods for the Solution of Transport Problems](https://www.cambridge.org/us/academic/subjects/engineering/chemical-engineering/computational-transport-phenomena-numerical-methods-solution-transport-problems). Cambridge University Press 
+
+ París, Federico, and José Cañas (1997) [Boundary Element Method: Fundamentals and Applications](https://www.amazon.com/Boundary-Element-Method-Fundamentals-Applications/dp/0198565372). Oxford University Press. Code at Burkardt's [site](https://people.math.sc.edu/Burkardt/f77_src/betis/betis.html). 
+
+ Itkin, A. L., and E. G. Kolesnichenko (1997). [Microscopic Theory of Condensation in Gases and Plasma](https://www.worldscientific.com/worldscibooks/10.1142/3325). World Scientific 
+
+ Fischer, Charlotte Frose, Tomas Brage, and Per Jonsson (1997). [Computational Atomic Structure: An MCHF Approach](https://www.routledge.com/Computational-Atomic-Structure-An-MCHF-Approach/Froese-Fischer/p/book/9780367401108). CRC Press. Code [here](https://www.pks.mpg.de/~george/HF/index.html), [here](https://github.com/cffischer), and [here](https://github.com/compas/atsp-book) 
+
+ Deutsch, C.V. and A.G. Journel (1997). [GSLIB: Geostatistical Software Library and Users Guide, 2nd. ed.](http://claytonvdeutsch.com/research/). Oxford University Press. Code [here](http://gslib.com/) 
+
+# 1996 
+
+ Siouris, George M. (1996). [An Engineering Approach to Optimal Control and Estimation Theory](https://www.wiley.com/en-us/An+Engineering+Approach+to+Optimal+Control+and+Estimation+Theory-p-9780471121268). Wiley 
+
+ Shashkov, Mikhail (1996). [Conservative Finite-Difference Methods on General Grids](https://www.amazon.com/Conservative-Finite-Difference-Methods-Symbolic-Computation/dp/0849373751). CRC 
+
+ Press, Teukolsky, Vetterling and Flannery (1996). [Numerical Recipes in Fortran 90 - The Art of Parallel Scientific Computing](http://fortranwiki.org/fortran/show/Numerical+Recipes+in+Fortran+90+-+The+Art+of+Parallel+Scientific+Computing). Cambridge University Press 
+
+ Kearfott, R. Baker (1996). [Rigorous Global Search: Continuous Problems](https://interval.louisiana.edu/books.html). Kluwer 
+
+ Hairer, Ernst, and Gerhard Wanner (1996). [Solving Ordinary Differential Equations II: Stiff and Differential-Algebraic Problems](https://www.springer.com/gp/book/9783540604525). Springer. code at Hairer’s [site](http://www.unige.ch/~hairer/software.html) 
+
+ Dennis, Jr., J.E., and Robert B. Schnabel (1996). [Numerical Methods for Unconstrained Optimization and Nonlinear Equations](https://my.siam.org/Store/Product/viewproduct/?ProductId=755). SIAM. Fortran 90 code for UNCMIN at Alan Miller’s [site](https://jblevins.org/mirror/amiller/) 
+
+ Bartschat, Klaus (Ed.) (1996). [Computational Atomic Physics: Electron and Positron Collisions with Atoms and Ions](https://www.springer.com/us/book/9783642646553). Springer 
+
+# 1995 
+
+ Tikhonov, A.N., Goncharsky, A., Stepanov, V.V., and Yagola, A.G. (1995). [Numerical Methods for the Solution of Ill-Posed Problems](https://www.springer.com/us/book/9780792335832). Springer 
+
+ Späth, Helmuth (1995). [Two Dimensional Spline Interpolation Algorithms](https://www.routledge.com/Two-Dimensional-Spline-Interpolation-Algorithms/Spath/p/book/9780367449926). CRC 
+
+ Späth, Helmuth (1995). [One Dimensional Spline Interpolation Algorithms](https://www.routledge.com/One-Dimensional-Spline-Interpolation-Algorithms/Spath/p/book/9780367449070). CRC 
+
+ Lawson, Charles L., and Richard J. Hanson (1995). [Solving Least Squares Problems](https://epubs.siam.org/doi/book/10.1137/1.9781611971217). SIAM original code at [Netlib](http://www.netlib.org/lawson-hanson/), modernized code at [GitHub](https://github.com/ivan-pi/fortran_lsp). Bounded Variable Least Squares Solver [here](https://people.sc.fsu.edu/~jburkardt/f_src/bvls/bvls.html), Nonnegative Least Squares [here](https://jblevins.org/mirror/amiller/nnls.f90). 
+
+ Coker, A. Kayode (1995). [Fortran Programs for Chemical Process Design, Analysis, and Simulation](https://www.elsevier.com/books/fortran-programs-for-chemical-process-design-analysis-and-simulation/coker/978-0-88415-280-4). Gulf Professional 
+
+# 1994 
+
+ Garcia, Alejandro L. (1994). [Numerical Methods for Physics](http://www.algarcia.org/nummeth/nummeth.html). Prentice Hall 
+
+ DeVries, Paul L. (1994). [A First Course in Computational Physics](https://www.amazon.com/First-Course-Computational-Physics/dp/0471548693/fortran-wiki-20). Wiley. reviewed [here](https://aapt.scitation.org/doi/abs/10.1119/1.17476) 
+
+ Akin, J. E. (1994). [Finite Elements for Analysis and Design](https://www.sciencedirect.com/book/9780080506470/finite-elements-for-analysis-and-design). Academic Press 
+
+# 1993 
+
+ Moré, Jorge J. and Stephen J. Wright (1993). [Optimization Software Guide](https://epubs.siam.org/doi/book/10.1137/1.9781611970951). SIAM. Wright helped create the [NEOS Guide](https://neos-guide.org/) 
+
+ Marazzi, Alfio (1993). [Algorithms, Routines, and S-Functions for Robust Statistics](https://www.routledge.com/Algorithms-Routines-and-S-Functions-for-Robust-Statistics/Marazzi/p/book/9780412079917). Chapman and Hall/CRC. FORTRAN 77 code available in [robeth](https://cran.r-project.org/web/packages/robeth/index.html) R package 
+
+ Leffelaar P. A. (1993). [On Systems Analysis and Simulation of Ecological Processes with Examples in CSMP and FORTRAN](https://www.springer.com/us/book/9789401120869). Springer 
+
+ Hairer, Ernst, Syvert P. Nørsett, and Gerhard Wanner (1993). [Solving Ordinary Differential Equations I: Nonstiff Problems](https://www.springer.com/gp/book/9783540566700). Springer. code at Hairer’s [site](http://www.unige.ch/~hairer/software.html) 
+
+ Dierckx, Paul (1993). [Curve and Surface Fitting with Splines](https://global.oup.com/academic/product/curve-and-surface-fitting-with-splines-9780198534402). Oxford. code [here](http://www.netlib.org/dierckx/) 
+
+ Crawley, Stanley W., and Robert M. Dillon (1993) [Steel Buildings: Analysis and Design, 4th ed.](https://www.amazon.com/Steel-Buildings-Analysis-Stanley-Crawley/dp/0471842982/fortran-wiki-20). Wiley 
+
+# 1992 
+
+ Wesseling, Pieter (1992). [An Introduction to Multigrid Methods](https://www.amazon.com/Pieter-Wesseling-Introduction-Multigrid-Methods/dp/B008UBETYE/fortran-wiki-20). Wiley. Code by Wesseling [here](http://www.mgnet.org/mgnet-codes.html) 
+
+ Stearns, Samuel D., and Ruth A. David (1992). [Signal Processing Algorithms in Fortran and C](https://www.amazon.com/Signal-Processing-Algorithms-Fortran-Prentice-Hall/dp/0138126941/fortran-wiki-20). Prentice-Hall 
+
+ Press, Flannery, Teukolsky, and Vetterling (1992). [Numerical Recipes in Fortran 77](http://fortranwiki.org/fortran/show/Numerical+Recipes+in+Fortran+77). Cambridge University Press. 
+
+# 1991 
+
+ Späth, Helmuth (1991). [Mathematical Algorithms for Linear Regression](https://www.elsevier.com/books/mathematical-algorithms-for-linear-regression/spath/978-0-12-656460-0). Academic Press. Fortran 90 code at John Burkardt’s [site](https://people.math.sc.edu/Burkardt/f_src/regression/regression.html) 
+
+ Schiesser, W. E. (1991). [The Numerical Method of Lines: Integration of Partial Differential Equations 1st ed.](https://www.amazon.com/Numerical-Method-Lines-Integration-Differential/dp/0126241309). Academic Press 
+
+ Greenspan, Donald (1991). [Quasimolecular Modelling](https://www.amazon.com/Quasimolecular-Modelling-Scientific-Lecture-Physics/dp/9810207190/fortran-wiki-20). World Scientific 
+
+ Fletcher, C. A. J. (1991). [Computational Techniques for Fluid Dynamics 2: Specific Techniques for Different Flow Categories](https://www.springer.com/us/book/9783540536017). Springer 
+
+# 1990 
+
+ Martello, Silvano, and Paolo Toth (1990). [Knapsack Problems: Algorithms and Computer Implementations](http://www.or.deis.unibo.it/kp.html). 
+
+ Koonin, Steven E., and Dawn C. Meredith (1990). [Computational Physics: Fortran Version](https://mypages.unh.edu/dawnm/computationalphysics). Westview Press 
+
+ Harrison, Howard B. (1990). [Structural Analysis and Design: Some Microcomputer Applications, 2nd. ed.](https://www.amazon.com/Structural-Analysis-Design-Microcomputer-Applications/dp/0080375219). Pergamon 
+
+# 1989 
+
+ Szabo, Attila, and Neil S. Ostlund (1989). [Modern Quantum Chemistry: Introduction to Advanced Electronic Structure Theory](https://store.doverpublications.com/0486691861.html). McGraw-Hill. Code [here](http://www.ccl.net/cca/software/SOURCES/FORTRAN/szabo/index.html) 
+
+ Lau, Hang Tong (1989). [Algorithms on Graphs](https://www.amazon.com/Algorithms-Graphs-H-T-Lau/dp/0830634290). Tab Books. Fortran 90 version of code at Burkardt’s [site](https://people.sc.fsu.edu/~jburkardt/f_src/laupack/laupack.html) 
+
+ Gonin, Rene, and Arthur H. Money (1989). [Nonlinear Lp-Norm Estimation](https://www.routledge.com/Nonlinear-Lp-Norm-Estimation/Gonin/p/book/9780367451165). CRC 
+
+# 1988 
+
+ Schmid, Erich W., Gerhard Spitz, and Wolfgang Losch (1988). [Theoretical Pbyslcs on the Personal Computer](https://link.springer.com/book/10.1007/978-3-642-75471-5). Springer. Reviewed [here](https://aip.scitation.org/doi/10.1063/1.4822844) 
+
+ Orfanidis, Sophocles J. (1988). [Optimum Signal Processing](https://www.ece.rutgers.edu/~orfanidi/osp2e/index.html). Wiley 
+
+ Newton, H. Joseph (1988). [Timeslab: A Time Series Analysis Laboratory](https://www.amazon.com/Timeslab-Laboratory-Diskettes-Statistics-Probability/dp/0534091989/fortran-wiki-20). Wadsworth & Brook/Cole. Timeslab code at author’s [site](https://web.stat.tamu.edu/~jnewton/) 
+
+ Moursund, David G., and Charles S. Duris (1988). [Elementary Theory and Application of Numerical Analysis](https://www.amazon.com/Elementary-Theory-Application-Numerical-Analysis/dp/048665754X/fortran-wiki-20). Dover 
+
+ Jones, Russell K., and Tracy Crabtree (1988). [FORTRAN Tools for VAX/VMS and MS-DOS](https://www.amazon.com/FORTRAN-Tools-VAX-VMS-MS-DOS/dp/0471619760/fortran-wiki-20). Wiley 
+
+ Hager, William (1988). [Applied Numerical Linear Algebra](https://www.amazon.com/Applied-Numerical-Linear-Algebra-William/dp/0130412945). Prentice Hall. NAPACK code at John Burkardt's [site](https://people.sc.fsu.edu/~jburkardt/f77_src/napack/napack.html) 
+
+ Dagpunar, John (1988). [Principles of Random Variate Generation](https://www.amazon.com/Principles-Random-Variate-Generation-Dagpunar/dp/0198522029/fortran-wiki-20). Oxford University Press. Related Fortran 90 [code](https://jblevins.org/mirror/amiller/random.f90) from Alan Miller. 
+
+# 1987 
+
+ Schmidt, Bernd (1987). [Model Construction with GPSS-FORTRAN Version 3](https://www.springer.com/gp/book/9781461291404). Springer. 
+
+ Schittkowski, Klaus (1987). [More Test Examples for Nonlinear Programming Codes](https://www.springer.com/us/book/9783540171829). Springer. Code [here](http://klaus-schittkowski.de/tpnp.htm) 
+
+ Marple, S. Lawrence (1987). [Digital Spectral Analysis with Applications](https://www.amazon.com/Spectral-Applications-Prentice-Hall-Processing-1987-03-01/dp/B01K0PWLCO/fortran-wiki-20). Prentice-Hall. Reviewed [here](https://asa.scitation.org/doi/pdf/10.1121/1.398548). Second [edition](https://www.doverpublications.com/048678052x/) has Matlab code. 
+
+ Hughes, Thomas J. R. (1987). [The Finite Element Method: Linear Static and Dynamic Finite Element Analysis](https://store.doverpublications.com/0486411818.html). Prentice-Hall. Related code [DLEARN](https://www.zsoil.com/dlearn/) 
+
+ Fenner, D. N. (1987). [Engineering stress analysis: A finite element approach with FORTRAN 77 software](https://www.amazon.com/Engineering-Stress-Analysis-mechanical-engineering/dp/074580246X/fortran-wiki-20). Ellis Horwood 
+
+ Bratley, Paul, Bennet L. Fox, and Linus E. Schrage (1987). [A Guide to Simulation, 2nd. ed.](https://www.springer.com/us/book/9780387964676). Springer. 
+
+ Angell, Ian O., and Gareth Griffith (1987). [High-resolution Computer Graphics Using FORTRAN 77](https://link.springer.com/book/10.1007/978-1-349-18644-0). Palgrave Macmillan 
+
+# 1986 
+
+ Parsons, Thomas W. (1986) [Voice and Speech Processing](https://www.amazon.com/gp/product/0070485410). McGraw-Hill. Appendix B has code for FFT and time series analysis. 
+
+ Lau, Hang Tong (1986). [Combinatorial Heuristic Algorithms with FORTRAN](https://www.springer.com/us/book/9783540171614). Springer 
+
+ Kagiwada, Harriet, Robert Kalaba, Nima Rasakhoo, and Karl Spingarn (1986). [Numerical Derivatives and Nonlinear Analysis](https://www.springer.com/us/book/9781468450583). Springer 
+
+ Devroye, Luc (1986). [Non-Uniform Random Variate Generation](http://luc.devroye.org/rnbookindex.html). Springer. Devroye [says](http://luc.devroye.org/rng.html)“[Alan Miller](https://jblevins.org/mirror/amiller/) … programmed most algorithms” from the book. 
+
+# 1985 
+
+ Sinha, Mihir K., and Larry R. Padgett (1985). [Reservoir Engineering Techniques Using Fortran](https://www.springer.com/us/book/9789027719218). Springer 
+
+ Griffiths, P., and Ian D. Hill (1985). [Applied Statistics Algorithms](https://www.amazon.com/Applied-Statistics-Algorithms-Mathematics-Applications/dp/0470201843/fortran-wiki-20). Ellis Horwood. Applied statistics codes [here](http://lib.stat.cmu.edu/apstat/). 
+
+ Cullum, Jane K. and Ralph A. Willoughby (1985) [Lanczos Algorithms for Large Symmetric Eigenvalue Computations: Vol. I: Theory](https://epubs.siam.org/doi/book/10.1137/1.9780898719192). Birkhauser. Code and text of 2nd volume at [Netlib](http://www.netlib.org/lanczos/) 
+
+# 1984 
+
+ Osyczka, Andrzej (1984). [Multicriterion Optimization in Engineering with FORTRAN Programs](https://www.amazon.com/Multicriterion-Optimization-Engineering-FORTRAN-Programs/dp/B002IXMBH2/fortran-wiki-20). Halsted/Wiley 
+
+ Moran, Jack (1984). [An Introduction to Theoretical and Computational Aerodynamics](https://store.doverpublications.com/0486428796.html). Wiley. Reviewed [here](https://arc.aiaa.org/doi/10.2514/3.48703) 
+
+ Fletcher, C. A. J. (1984). [Computational Galerkin Methods](https://www.springer.com/us/book/9783642859519). Springer 
+
+ Dhatt, Gouri, and Gilbert Touzot (1984). [The Finite Element Method Displayed](https://www.amazon.com/Finite-Element-Method-Displayed/dp/0471901105). Wiley. Code at [GitHub](https://github.com/freevryheid/FEM/tree/master/DT) 
+
+ Davis, Philip J., and Philip Rabinowitz (1984). [Methods of Numerical Integration, 2nd. ed.](https://store.doverpublications.com/0486453391.html). Academic Press 
+
+ Davis, Mark E. (1984). [Numerical Methods & Modeling for Chemical Engineers](https://www.amazon.com/Numerical-Modeling-Chemical-Engineers-Mathematics/dp/0486493830/fortran-wiki-20). Wiley 
+
+# 1983 
+
+ Bowyer, Adrian, and John Woodwark (1983).[A Programmer's Geometry](https://www.biblio.com/a-programmers-geometry-by-adrian-bowyer-john-woodwark/work/1845106). Butterworths 
+
+# 1982 
+
+ Wang, H. F., and M. P. Anderson (1982). [Introduction to groundwater modeling: Finite difference and finite element methods](https://www.elsevier.com/books/introduction-to-groundwater-modeling/wang/978-0-12-734585-7). Freeman. Code at Wang’s [site](http://geoscience.wisc.edu/geoscience/people/faculty/herb-wang/) 
+
+# 1981 
+
+ Smetana, Frederick O. (1981). [Fortran Codes for Classical Methods in Linear Dynamics](https://www.amazon.com/Fortran-Classical-Methods-Linear-Dynamics/dp/0070584400/fortran-wiki-20). McGraw-Hill 
+
+ IEEE (1981). [Programs for Digital Signal Processing](https://www.amazon.com/Programs-Processing-Institute-Electrical-Electronics/dp/0471059625). IEEE Press. Reviewed [here](https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=1456363) 
+
+ Hock, W., and Klaus Schittkowski (1981). [Test Examples for Nonlinear Programming Codes](https://www.springer.com/us/book/9783540105619). Springer. Code [here](http://klaus-schittkowski.de/tpnp.htm) 
+
+ Hageman, L. and D. M. Young (1981). [Applied Iterative Methods](https://store.doverpublications.com/0486153304.html). Academic Press. Related package: [NSPCG](https://web.ma.utexas.edu/CNA/NSPCG/) 
+
+ Gill, Philip E., Walter Murray, Margaret H. Wright (1981). [Practical Optimization](https://my.siam.org/Store/Product/viewproduct/?ProductId=31205265). Academic Press 
+
+# 1980 
+
+ Späth, Helmuth (1980). [Cluster Analysis Algorithms](https://www.amazon.com/Cluster-Analysis-Algorithms-Computers-applications/dp/0470269464/fortran-wiki-20). Halsted Press. Fortran 90 code at John Burkardt’s [site](https://people.sc.fsu.edu/~jburkardt/datasets/spaeth/spaeth.html) 
+
+ Schittkowski, Klaus (1980). [Nonlinear Programming Codes: Information, Tests, Performance](https://www.springer.com/us/book/9783540102472). Springer 
+
+ Prausnitz, J., T. Anderson, E. Grens, C. Eckert, R. Hsieh, and J. O’Connell, (1980). [Computer Calculations for Multicomponent Vapor-Liquid and Liquid-Liquid Equilibria](https://www.amazon.com/Calculations-Multicomponent-Liquid-Liquid-Prentice-Hall-international/dp/0131649620/fortran-wiki-20). Prentice-Hall. 
+
+ Finlayson, Bruce A. (1980). [Nonlinear Analysis in Chemical Engineering](http://www.chemecomp.com/resale/Nonlinear/program_index.htm). McGraw-Hill. 
+
+ Cody, William, and William Waite (1980). [Software Manual for the Elementary Functions](https://www.amazon.com/Elementary-Functions-Prentice-Hall-computational-mathematics/dp/0138220646). Prentice Hall. Code at Waite's [site](https://ecee.colorado.edu/~waite/pubs/math/Elefunt.html) 
+
+# 1979 
+
+ Hinton, E., and D. Owen (1979). [Finite Element Programming](https://www.elsevier.com/books/finite-element-programming/hinton/978-0-08-091871-6). Academic Press 
+
+# 1978 
+
+ Villadsen, John, and Michael L. Michelsen (1978). [Solution of Differential Equations Models by Polynomial Approximation](https://www.amazon.com/differential-approximation-Prentice-Hall-international-engineering/dp/0138222053). Prentice-Hall. Modernized code in [stiff3](https://github.com/ivan-pi/stiff3) on GitHub by Ivan Pribec 
+
+ Nijenhuis, Albert, and Herbert S. Wilf (1978). [Combinatorial Algorithms 
+
+ Boor, Carl de (1978). [A Practical Guide to Splines](https://www.springer.com/gp/book/9780387953663). Springer. PPPACK Fortran 90 code [here](https://people.sc.fsu.edu/~jburkardt/f_src/pppack/pppack.html) 
+
+# 1977 
+
+ Fuller, W. R. (1977). [FORTRAN Programming: A Supplement for Calculus Courses](https://www.springer.com/gp/book/9780387902838). Springer 
+
+ Forsythe, George E., Michael A. Malcolm, and Cleve B. Moler (1977). [Computer Methods for Mathematical Computations](https://www.amazon.com/Mathematical-Computations-Prentice-Hall-automatic-computation/dp/0131653326/fortran-wiki-20). Prentice-Hall. Code at [Netlib](http://www.netlib.org/fmm/index.html) 
+
+ Bierman, Gerald J. (1977). [Factorization Methods for Discrete Sequential Estimation](https://store.doverpublications.com/0486449815.html) Academic Press. (contains Fortran pseudo-code for numerically stable Kalman filters). The code in [esl.tgz from Netlib](https://www.netlib.org/a/) does estimation and smoothing by UDU**T and square root information filter SRIF for Kalman filtering. 
+
+# 1976 
+
+ Jeppson, Roland W. Jeppson (1976). [Analysis of Flow in Pipe Networks](https://www.amazon.com/Analysis-Flow-Networks-Roland-Jeppson/dp/0250401193/fortran-wiki-20). Butterworth-Heinemann. Modernization of codes discussed in [Recovery of Jeppson Pipe Network Analysis Software](http://www.acorvid.com/wp-content/uploads/2018/03/wp-20180307-jeppson-1.pdf) by Bob Apthorpe 
+
+ Bloomfield, Peter (1976). [Fourier Analysis of Time Series, 1st ed.](https://books.google.com/books?id=UtpQAAAAMAAJ&source=gbs_book_other_versions). First edition has Fortran code, the 2nd edition, published in 2000, has S-PLUS code. 
+
+# 1975 
+
+ Shampine, Lawrence, and Marilyn Gordon (1975). [Computer Solution of Ordinary Differential Equations: The Initial Value Problem](https://www.amazon.com/Computer-solution-ordinary-differential-equations/dp/0716704617/fortran-wiki-20). Freeman. Code [translated](https://people.sc.fsu.edu/~jburkardt/f_src/ode/ode.html) to Fortran 90 by John Burkardt. 
+
+ Rabiner, Lawrence R., and Bernard Gold (1975). [Theory and Application of Digital Signal Processing](https://www.amazon.com/Theory-Application-Digital-Signal-Processing/dp/0139141014/fortran-wiki-20). Prentice Hall 
+
+ Hartigan, J. A. (1975). [Clustering Algorithms](https://www.amazon.com/exec/obidos/ASIN/047135645X/acmorg-20/fortran-wiki-20). Wiley. Code in the [Cluster](https://orion.math.iastate.edu/docs/cmlib/cluster.html) section of CMLIB. 
+
+ Akaike, Hirotsugu (1975). [TIMSAC-74, a time series analysis and control program package](https://www.amazon.com/TIMSAC-74-analysis-control-Computer-monographs/dp/B0007B3OIW/fortran-wiki-20). Institute of Statistical Mathematics. R package [timsac: Time Series Analysis and Control](https://cran.r-project.org/web/packages/timsac/index.html) has Fortran code. 
+
+# 1973 
+
+ Land, A., and S. Powell (1973). [Fortran codes for mathematical programming: linear, quadratic and discrete](https://www.amazon.com/Fortran-codes-mathematical-programming-quadratic/dp/0471512702/fortran-wiki-20). Wiley 
+
+ Kuester, James L., and Joe H. Mize (1973). [Optimization Techniques with Fortran](https://www.amazon.com/Optimization-Techniques-Fortran-Kuester-1973-06-01/dp/B01A64AHLQ/fortran-wiki-20). McGraw-Hill 
+
+ Harrison, Howard B. (1973). [Computer methods in structural analysis](https://trid.trb.org/view/135613). Prentice-Hall 
+
+ Brent, Richard (1973). [Algorithms for Minimization without Derivatives](https://maths-people.anu.edu.au/~brent/pub/pub011.html). Prentice-Hall 
+
+# 1972 
+
+ Day, A. Colin (1972). [Fortran Techniques with Special Reference to Non-numerical Applications](https://www.cambridge.org/us/academic/subjects/computer-science/programming-languages-and-applied-logic/fortran-techniques-special-reference-non-numerical-applications). Cambridge University Press 
+
+# 1971 
+
+ Stroud, Arthur (1971). [Approximate Calculation of Multiple Integrals](https://www.amazon.com/Approximate-Calculation-0130438936-Prentice-Hall-Computation/dp/B004T9BACK). Prentice Hall. Fortran 90 code by John Burkardt [here](https://people.sc.fsu.edu/~jburkardt/f_src/stroud/stroud.html) 
+
+ Davies, R.G. (1971). [Computer Programming in Quantitative Biology](https://www.elsevier.com/books/computer-programming-in-quantitative-biology/davies/978-0-12-206250-6). Academic Press 
+
+# 1966 
+
+ Stroud, Arthur, and Don Secrest (1966). [Gaussian Quadrature Formulas](https://www.amazon.com/Gaussian-quadrature-Prentice-Hall-automatic-computation/dp/B0006BNRQ2). Prentice Hall. Fortran 90 code by John Burkardt [here](https://people.sc.fsu.edu/~jburkardt/f_src/stroud/stroud.html) and by Ivan Pribec [here](https://github.com/ivan-pi/stroud_quad) 
+
+# 1964 
+
+ Traub, Joseph (1964). [Iterative Methods for the Solution of Equations](https://www.amazon.com/Iterative-Methods-Solution-Equations-Publication/dp/0828403120) Prentice Hall. Code by John Burkardt [here](https://people.sc.fsu.edu/~jburkardt/f_src/zoomin/zoomin.html) 
+

--- a/timeline.sh
+++ b/timeline.sh
@@ -42,7 +42,7 @@ sort -k 1 -nr tmp01 > tmp02
 # group the entries per year of publication
 awk 'BEGIN {year=9999}; \
     $1 != year {year = $1; print "##", year"\n"}; \
-    $1 == year {$1=""; print $0"\n"}' tmp02 > tmp03
+    $1 == year {gsub(/^[0-9]{4} /, ""); print$0"\n";}' tmp02 > tmp03
 
 # join original header and reorganized timeline
 awk 'NR <= 3 {print}' "$1" > Fortran_timeline.md

--- a/timeline.sh
+++ b/timeline.sh
@@ -20,6 +20,7 @@
 # + awk
 # + bash
 # + cat
+# + fmt
 # + rm
 # + sort
 #
@@ -47,6 +48,11 @@ awk 'BEGIN {year=9999}; \
 # join original header and reorganized timeline
 awk 'NR <= 3 {print}' "$1" > Fortran_timeline.md
 cat tmp03 >> Fortran_timeline.md
+
+# remove overly long lines
+fmt -w 80 ./Fortran_timeline.md > tmp04
+mv ./tmp04 Fortran_timeline.md
+
 
 # space cleaning
 rm tmp01 tmp02 tmp03

--- a/timeline.sh
+++ b/timeline.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/bash
+
+# name:    timeline.sh
+# author:  nbehrnd@yahoo.com
+# license: GPL, v2.
+# date:    [2022-06-29]
+# edit:
+
+# Reverse sort of Beliavsky's compilation of books about Fortran.
+#
+# The already existing compilation of books about Fortran sorts the entries by
+# the family name of the first author of the book in question (alphabetical,
+# ascending sequence).  As suggested by one reader, a second version of the list
+# were helpful with the entries presented in a geological sort by the date of
+# publication (numerical, descending sequence).  The required information is
+# provided by the entries in the pattern YYYY.
+#
+# To work, this bash script depends on
+#
+# + awk
+# + bash
+# + cat
+# + rm
+# + sort
+#
+# as available e.g., in Linux Debian 12/bookworm (branch testing).  By an input
+# of either
+#
+# bash timeline.sh [filename]
+# ./timeline.sh [filename]  # after provision of the executable bit
+#
+# a new file `Fortran_timeline.md` is written, ready for deposit on GitHub.  If
+# present, an earlier version of `Fortran_timeline.md` is going to be replaced.
+
+
+awk -e 'match($0, /[12][0-9]{3}/)  {print \
+    substr($0, RSTART, RLENGTH), $0}' "$1" > tmp01
+
+sort -k 1 -nr tmp01 > tmp02
+
+awk 'BEGIN {year=9999}; \
+    $1 != year {year = $1; print "#", year, "\n"}; \
+    $1 == year {$1=""; print $0, "\n"}' tmp02 > tmp03
+
+awk 'NR <= 3 {print}' "$1" > Fortran_timeline.md
+cat tmp03 >> Fortran_timeline.md
+
+rm tmp01 tmp02 tmp03

--- a/timeline.sh
+++ b/timeline.sh
@@ -3,8 +3,8 @@
 # name:    timeline.sh
 # author:  nbehrnd@yahoo.com
 # license: GPL, v2.
-# date:    [2022-06-29]
-# edit:
+# date:    [2022-06-29 Wed]
+# edit:    [2023-03-13 Mon]
 
 # Reverse sort of Beliavsky's compilation of books about Fortran.
 #
@@ -32,17 +32,21 @@
 # a new file `Fortran_timeline.md` is written, ready for deposit on GitHub.  If
 # present, an earlier version of `Fortran_timeline.md` is going to be replaced.
 
-
+# report the year of publication identified as leading entry per record
 awk -e 'match($0, /[12][0-9]{3}/)  {print \
     substr($0, RSTART, RLENGTH), $0}' "$1" > tmp01
 
+# sort the entries by year of publication (most recent year first)
 sort -k 1 -nr tmp01 > tmp02
 
+# group the entries per year of publication
 awk 'BEGIN {year=9999}; \
     $1 != year {year = $1; print "#", year, "\n"}; \
     $1 == year {$1=""; print $0, "\n"}' tmp02 > tmp03
 
+# join original header and reorganized timeline
 awk 'NR <= 3 {print}' "$1" > Fortran_timeline.md
 cat tmp03 >> Fortran_timeline.md
 
+# space cleaning
 rm tmp01 tmp02 tmp03

--- a/timeline.sh
+++ b/timeline.sh
@@ -41,8 +41,8 @@ sort -k 1 -nr tmp01 > tmp02
 
 # group the entries per year of publication
 awk 'BEGIN {year=9999}; \
-    $1 != year {year = $1; print "#", year, "\n"}; \
-    $1 == year {$1=""; print $0, "\n"}' tmp02 > tmp03
+    $1 != year {year = $1; print "##", year"\n"}; \
+    $1 == year {$1=""; print $0"\n"}' tmp02 > tmp03
 
 # join original header and reorganized timeline
 awk 'NR <= 3 {print}' "$1" > Fortran_timeline.md


### PR DESCRIPTION
There has been the suggestion to provide the listing in anti-
chronological sequence of date of publication.[1]  The bash script
provides the reorganization, the .md is an example of application.

[1] https://github.com/Beliavsky/Fortran-related-books/issues/3